### PR TITLE
Fix hipfb files not installed on the first build+install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,10 +585,10 @@ install(FILES ${HIPRT_ORO_HEADERS}
 		DESTINATION include/contrib/Orochi/ParallelPrimitives)
 
 # add hipfb files
-file(GLOB HIPRT_HIPFB_FILES "${BASE_OUTPUT_DIR}/${CMAKE_BUILD_TYPE}/*.hipfb")
-install(FILES ${HIPRT_HIPFB_FILES}
-		DESTINATION bin)
-
+if(PRECOMPILE)
+	install(FILES ${KERNEL_HIPRT_COMP} ${KERNEL_OROCHI_COMP}
+			DESTINATION bin)
+endif()
 
 
 


### PR DESCRIPTION
A small oversight in the 109e7fe6 which made it so hipfb files are not recompiled on every CMake run and that they detect changes in dependencies.

The GLOB used for the install target runs at the configure time, so it was missing these files as they are generated at the compile time.

Use explicit list of hipfb files, which solves this issue, and also avoids install of hipfb used for the regression tests.