### PR TITLE
Fix missing target dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,7 +503,7 @@ if ( BAKE_COMPILED_KERNEL )
 
 	# Create the 'bake_compiled_kernels' project
 	add_custom_target(bake_compiled_kernels ALL
-		DEPENDS ${KERNEL_HIPRT_H} ${KERNEL_OROCHI_H}
+		DEPENDS ${KERNEL_HIPRT_H} ${KERNEL_OROCHI_H} precompile_kernels
 	)
 
 	add_dependencies(${HIPRT_NAME} precompile_kernels bake_compiled_kernels)


### PR DESCRIPTION
Don;t only rely on file names for dependencies but also depend on target. This fixes multiple compile.py processes running in parallel for the different users.

In practice the error behavior could have been seen by running `make -j` and observe the following output:

```
compiling hiprt02005_6.1_amd_lib_linux.bc...
compiling hiprt02005_6.1_amd_lib_linux.bc...
```