### PR TITLE
Fix compilation error using SDK 6.3

### DIFF
--- a/scripts/bitcodes/compile.py
+++ b/scripts/bitcodes/compile.py
@@ -100,7 +100,7 @@ def compileAmd():
     
 
     if hip_sdk_version_num >= 63:
-        gpus_archs.append('gfx1152')
+        gpus.append('gfx1152')
 
     if hip_sdk_version_num >= 62: # Navi4 supported from 6.2
         gpus.append('gfx1200')

--- a/scripts/bitcodes/precompile_bitcode.py
+++ b/scripts/bitcodes/precompile_bitcode.py
@@ -107,7 +107,7 @@ def compileAmd():
     
 
     if hip_sdk_version_num >= 63:
-        gpus_archs.append('gfx1152')
+        gpus.append('gfx1152')
 
     if hip_sdk_version_num >= 62: # Navi4 supported from 6.2
         gpus.append('gfx1200')


### PR DESCRIPTION
Recent commit added support for gfx1152 but used an uninitialized variable `gpus_archs`.

Follow the same code as for SDK 6.2 and use gpus.append() instead.

---

This fixes the following compilation error:

[  3%] Precompiling kernels via compile.py
Compile kernel using hip sdk: /opt/rocm
HIP version: 6.3.42133-1b9c17779
AMD clang version 18.0.0git (https://github.com/RadeonOpenCompute/llvm-project roc-6.3.1 24491 1e0fda770a2079fbd71e4b70974d74f62fd3af10) Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/rocm-6.3.1/lib/llvm/bin
Configuration file: /opt/rocm-6.3.1/lib/llvm/bin/clang++.cfg Traceback (most recent call last):
  File "/home/sergey/Developer/build_linux/deps_x64/build/hiprt/src/external_hiprt/scripts/bitcodes/compile.py", line 209, in <module>
    compileAmd()
  File "/home/sergey/Developer/build_linux/deps_x64/build/hiprt/src/external_hiprt/scripts/bitcodes/compile.py", line 103, in compileAmd
    gpus_archs.append('gfx1152')
    ^^^^^^^^^^
NameError: name 'gpus_archs' is not defined