### PR TITLE
Fix baked kernels failure when application has space in its path

### DIFF
--- a/hiprt/impl/Compiler.cpp
+++ b/hiprt/impl/Compiler.cpp
@@ -776,7 +776,15 @@ oroFunction Compiler::getFunctionFromPrecompiledBinary( const std::string& funcN
 			// kernel.
 			if constexpr ( UseBakedCompiledKernel )
 			{
-				checkOro( oroModuleLoadData( &module, &bvh_build_array_h ) );
+				// Copy the data into a heap memory.
+				//
+				// Otherwise it seems to be causing issues with access from the HIP SDK when the application binary is
+				// located in a directory with space in it.
+				//
+				// The speculation is that static global memory can not really be megabytes, and access to it requires
+				// mapping of the original file, and this is where things start to go wrong.
+				std::vector<char> binary(bvh_build_array_h, bvh_build_array_h + bvh_build_array_h_size);
+				checkOro( oroModuleLoadData( &module, binary.data() ) );
 			}
 			else
 			{


### PR DESCRIPTION
When baked kernels are used and the application contains space in the part to its executable rendering will fail on Linux.

The exact details of why it happens are not very clear from our side, but seemingly it is caused by the fact that HIP-RT is passing a large global array to a different library (HIP driver, via hipModuleLoadData). Having global variables of such size seems to be always problematic as they can not be stored on stack and, possibly, extra mapping is involved here. It is not clear whether it is a quirk of the HIP driver, or Linux, or, maybe, something completely different.

It is possible to work-around the problem by making a temporary copy of data on heap memory and pass it to the hipModuleLoadData(). This is how other areas are dealing with modules in Blender.

This change contains patch against HIP-RT and the new HIP-RT library compiled with the patch. It seems to fix the problem reported in the report.

Original report on Blender side: https://projects.blender.org/blender/blender/issues/134992
Original PR on Blender side: https://projects.blender.org/blender/blender/pulls/135403