### PR TITLE
Skip installation of baked hipfb files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,7 +585,7 @@ install(FILES ${HIPRT_ORO_HEADERS}
 		DESTINATION include/contrib/Orochi/ParallelPrimitives)
 
 # add hipfb files
-if(PRECOMPILE)
+if(PRECOMPILE AND NOT BAKE_COMPILED_KERNEL)
 	install(FILES ${KERNEL_HIPRT_COMP} ${KERNEL_OROCHI_COMP}
 			DESTINATION bin)
 endif()


### PR DESCRIPTION
The files are included into the library itself as data, there is no need to install them, as they are not supposed to be used.