### PR TITLE
Fail if bitcode compilation fails

### DIFF
--- a/scripts/bitcodes/compile.py
+++ b/scripts/bitcodes/compile.py
@@ -58,8 +58,10 @@ def compileScript(cmd, dst):
     return_code = subprocess.call(cmd, shell=True)
     if return_code != 0:
         print(errorMessageHeader + ' executing command: ' + cmd)
+        sys.exit(1)
     elif not os.path.exists(dst):
         print(errorMessageHeader + ' The file ' + dst + ' does not exist.')
+        sys.exit(1)
     else:
         print('Compilation SUCCEEDED.')
     sys.stdout.flush()
@@ -84,6 +86,7 @@ def compileAmd():
     return_code = subprocess.call(cmd, shell=True)
     if return_code != 0:
         print(errorMessageHeader + ' executing command: ' + cmd)
+        sys.exit(1)
 
     result = subprocess.check_output(cmd, shell=True)
     hip_sdk_version = result.decode('utf-8')

--- a/scripts/bitcodes/precompile_bitcode.py
+++ b/scripts/bitcodes/precompile_bitcode.py
@@ -60,8 +60,10 @@ def compileScript(msg, cmd, dst):
     return_code = subprocess.call(cmd, shell=True)
     if return_code != 0:
         print(errorMessageHeader + ' executing command: ' + cmd)
+        sys.exit(1)
     elif not os.path.exists(dst):
         print(errorMessageHeader + ' The file ' + dst + ' does not exist.')
+        sys.exit(1)
     else:
         print('Compilation SUCCEEDED.')
     sys.stdout.flush()


### PR DESCRIPTION
Instead of ignoring compilation errors and building potentially incomplete bundles/packages, fail if any kernel compilation fails.

Closes #42