### PR TITLE
fix multi gpu setup

### DIFF
--- a/contrib/Orochi/Orochi/Orochi.cpp
+++ b/contrib/Orochi/Orochi/Orochi.cpp
@@ -938,8 +938,9 @@ oroDevice oroGetRawDevice( oroDevice dev )
 
 oroDevice oroSetRawDevice( oroApi api, oroDevice dev ) 
 {
-	ioroDevice d( dev );
+	ioroDevice d{};
 	d.setApi( api );
+	d.setDevice( dev );
 	return *(oroDevice*)&d;
 }
 

--- a/hiprt/impl/Compiler.cpp
+++ b/hiprt/impl/Compiler.cpp
@@ -69,7 +69,8 @@ HIPRT_STATIC_ASSERT( !UseBakedCode || BakedCodeIsGenerated );
 
 namespace hiprt
 {
-Compiler::Compiler()
+
+void Compiler::init()
 {
 	if ( UseBitcode || UseBakedCompiledKernel || hiprtcCreateProgram == nullptr || hiprtcCompileProgram == nullptr ||
 		 hiprtcDestroyProgram == nullptr )

--- a/hiprt/impl/Compiler.h
+++ b/hiprt/impl/Compiler.h
@@ -35,8 +35,9 @@ class Context;
 class Compiler
 {
   public:
-	Compiler();
 	~Compiler();
+
+	void init();
 
 	Kernel getKernel(
 		Context&					 context,

--- a/hiprt/impl/Context.cpp
+++ b/hiprt/impl/Context.cpp
@@ -39,6 +39,8 @@ Context::Context( const hiprtContextCreationInput& input )
 	oroApi api = ( input.deviceType == hiprtDeviceAMD ) ? ORO_API_HIP : ORO_API_CUDA;
 	oroCtxCreateFromRaw( &m_ctxt, api, input.ctxt );
 	m_device = oroSetRawDevice( api, input.device );
+	checkOro( oroCtxSetCurrent( m_ctxt ) );
+	m_compiler.init();
 }
 
 Context::~Context()


### PR DESCRIPTION
This PR fixes two issues that prevent HIPRT from working correctly on multi-GPU setups:

1. An Orochi bug. A minimal fix is included here to make the root cause obvious, but the preferred upstream fix is the one from https://github.com/GPUOpen-LibrariesAndSDKs/Orochi/pull/135, which removes bit-field usage.
2. An issue in the `rtip31Support` check. The `Compiler` constructor is executed before the device is assigned, so the support check happens too early.