### PR TITLE
Adapt HIPRT compilation for TheRock wheel builds

### DIFF
--- a/contrib/Orochi/contrib/hipew/src/hipew.cpp
+++ b/contrib/Orochi/contrib/hipew/src/hipew.cpp
@@ -46,6 +46,10 @@
 #  define WIN32_LEAN_AND_MEAN
 #  define VC_EXTRALEAN
 #  include <windows.h>
+#  include <algorithm>
+#  include <cstdlib>
+#  include <string>
+#  include <vector>
 
 /* Utility macros. */
 
@@ -54,6 +58,93 @@ typedef HMODULE DynamicLibrary;
 #  define dynamic_library_open(path)         LoadLibraryA(path)
 #  define dynamic_library_close(lib)         FreeLibrary(lib)
 #  define dynamic_library_find(lib, symbol)  GetProcAddress(lib, symbol)
+
+static std::string hipew_get_env(const char* name)
+{
+  char* value = nullptr;
+  size_t size = 0;
+  if (_dupenv_s(&value, &size, name) != 0 || value == nullptr)
+    return std::string();
+  std::string result(value);
+  std::free(value);
+  return result;
+}
+
+static bool hipew_directory_exists(const std::string& path)
+{
+  if (path.empty())
+    return false;
+  DWORD attributes = GetFileAttributesA(path.c_str());
+  return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+static std::string hipew_join_path(const std::string& base, const char* leaf)
+{
+  if (base.empty())
+    return std::string(leaf);
+  const char last = base.back();
+  if (last == '\\' || last == '/')
+    return base + leaf;
+  return base + "\\" + leaf;
+}
+
+static void hipew_append_unique(std::vector<std::string>& paths, const std::string& path)
+{
+  if (path.empty() || std::find(paths.begin(), paths.end(), path) != paths.end())
+    return;
+  paths.push_back(path);
+}
+
+static void hipew_append_rocm_bin(std::vector<std::string>& paths, const std::string& root)
+{
+  if (root.empty())
+    return;
+  if (hipew_directory_exists(root))
+    hipew_append_unique(paths, root);
+  const std::string bin = hipew_join_path(root, "bin");
+  if (hipew_directory_exists(bin))
+    hipew_append_unique(paths, bin);
+}
+
+static std::vector<std::string> hipew_rocm_bin_paths()
+{
+  std::vector<std::string> result;
+
+  hipew_append_rocm_bin(result, hipew_get_env("ROCM_HOME"));
+  hipew_append_rocm_bin(result, hipew_get_env("ROCM_PATH"));
+  hipew_append_rocm_bin(result, hipew_get_env("HIP_PATH"));
+
+  const std::string virtual_env = hipew_get_env("VIRTUAL_ENV");
+  if (!virtual_env.empty()) {
+    hipew_append_rocm_bin(result, hipew_join_path(virtual_env, "Lib\\site-packages\\_rocm_sdk_devel"));
+    hipew_append_rocm_bin(result, hipew_join_path(virtual_env, "Lib\\site-packages\\rocm_sdk_devel"));
+  }
+
+  return result;
+}
+
+static const char** hipew_make_library_paths(
+    const char* const* dll_names,
+    std::vector<std::string>& storage,
+    std::vector<const char*>& pointers)
+{
+  storage.clear();
+  pointers.clear();
+
+  const std::vector<std::string> rocm_bins = hipew_rocm_bin_paths();
+
+  for (size_t i = 0; dll_names[i] != nullptr; ++i) {
+    hipew_append_unique(storage, dll_names[i]);
+    for (const std::string& bin : rocm_bins)
+      hipew_append_unique(storage, hipew_join_path(bin, dll_names[i]));
+  }
+
+  for (const std::string& path : storage)
+    pointers.push_back(path.c_str());
+  pointers.push_back(nullptr);
+
+  return pointers.data();
+}
 #else
 #  include <dlfcn.h>
 
@@ -619,12 +710,18 @@ void hipewInit( int* resultDriver, int* resultRtc, uint32_t flags, const char** 
 
 #ifdef _WIN32
   // Expected in C:/Windows/System32 or similar, no path needed.
-  const char* hip_paths[] = {
+  const char* hip_dll_names[] = {
       "amdhip64_7.dll", 
       "amdhip64_6.dll", 
       "amdhip64.dll",   // <- hip '5.x' DLL.
       NULL };
-  const char* hiprtc_paths[] = {
+  const char* hiprtc_dll_names[] = {
+      "hiprtc07013.dll",
+      "hiprtc07012.dll",
+      "hiprtc07011.dll",
+      "hiprtc07010.dll",
+      "hiprtc0709.dll",
+      "hiprtc0708.dll",
       "hiprtc0707.dll",
       "hiprtc0706.dll",
       "hiprtc0705.dll",
@@ -645,6 +742,12 @@ void hipewInit( int* resultDriver, int* resultRtc, uint32_t flags, const char** 
       "hiprtc0504.dll",
       "hiprtc0503.dll",
       NULL };
+  static std::vector<std::string> hip_path_storage;
+  static std::vector<const char*> hip_path_pointers;
+  static std::vector<std::string> hiprtc_path_storage;
+  static std::vector<const char*> hiprtc_path_pointers;
+  const char** hip_paths = hipew_make_library_paths(hip_dll_names, hip_path_storage, hip_path_pointers);
+  const char** hiprtc_paths = hipew_make_library_paths(hiprtc_dll_names, hiprtc_path_storage, hiprtc_path_pointers);
 #elif defined(__APPLE__)
   // Default installation path. 
   const char *hip_paths[] = {"", NULL};

--- a/hiprt/hiprt_libpath.h
+++ b/hiprt/hiprt_libpath.h
@@ -31,16 +31,108 @@
 
 #ifdef _WIN32
 
-const char* g_hip_paths[] = {
-	"amdhip64_7.dll",
-	"amdhip64_6.dll",
-	"amdhip64.dll", // <- hip '5.x' DLL.
-	nullptr };
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <vector>
 
-const char* g_hiprtc_paths[] = { "hiprtc0707.dll", "hiprtc0706.dll", "hiprtc0705.dll", "hiprtc0704.dll", "hiprtc0703.dll",
-								 "hiprtc0702.dll", "hiprtc0701.dll", "hiprtc0700.dll", "hiprtc0605.dll", "hiprtc0604.dll",
-								 "hiprtc0603.dll", "hiprtc0602.dll", "hiprtc0601.dll", "hiprtc0600.dll", "hiprtc0507.dll",
-								 "hiprtc0506.dll", "hiprtc0505.dll", "hiprtc0504.dll", "hiprtc0503.dll", nullptr };
+namespace hiprt
+{
+namespace detail
+{
+inline std::string getEnvVariable( const char* name )
+{
+	const char* value = std::getenv( name );
+	return value ? std::string( value ) : std::string();
+}
+
+inline std::string joinPath( const std::string& base, const char* leaf )
+{
+	if ( base.empty() ) return std::string( leaf );
+	const char last = base.back();
+	if ( last == '\\' || last == '/' ) return base + leaf;
+	return base + "\\" + leaf;
+}
+
+inline void appendUnique( std::vector<std::string>& paths, const std::string& path )
+{
+	if ( path.empty() || std::find( paths.begin(), paths.end(), path ) != paths.end() ) return;
+	paths.push_back( path );
+}
+
+inline void appendRocmRoot( std::vector<std::string>& paths, const std::string& root )
+{
+	if ( root.empty() ) return;
+	appendUnique( paths, root );
+	appendUnique( paths, joinPath( root, "bin" ) );
+}
+
+inline std::vector<std::string> rocmBinPaths()
+{
+	std::vector<std::string> result;
+	appendRocmRoot( result, getEnvVariable( "ROCM_HOME" ) );
+	appendRocmRoot( result, getEnvVariable( "ROCM_PATH" ) );
+	appendRocmRoot( result, getEnvVariable( "HIP_PATH" ) );
+
+	const std::string virtualEnv = getEnvVariable( "VIRTUAL_ENV" );
+	if ( !virtualEnv.empty() )
+	{
+		appendRocmRoot( result, joinPath( virtualEnv, "Lib\\site-packages\\_rocm_sdk_devel" ) );
+		appendRocmRoot( result, joinPath( virtualEnv, "Lib\\site-packages\\rocm_sdk_devel" ) );
+	}
+
+	return result;
+}
+
+inline const char** makeLibraryPaths(
+	const char* const*		  dllNames,
+	std::vector<std::string>& storage,
+	std::vector<const char*>& pointers )
+{
+	storage.clear();
+	pointers.clear();
+
+	const std::vector<std::string> rocmBins = rocmBinPaths();
+	for ( size_t i = 0; dllNames[i] != nullptr; ++i )
+	{
+		appendUnique( storage, dllNames[i] );
+		for ( const std::string& bin : rocmBins )
+			appendUnique( storage, joinPath( bin, dllNames[i] ) );
+	}
+
+	for ( const std::string& path : storage )
+		pointers.push_back( path.c_str() );
+	pointers.push_back( nullptr );
+
+	return pointers.data();
+}
+
+inline const char** getHipPaths()
+{
+	static const char*		  dllNames[] = { "amdhip64_7.dll", "amdhip64_6.dll", "amdhip64.dll", nullptr };
+	static std::vector<std::string> storage;
+	static std::vector<const char*> pointers;
+	return makeLibraryPaths( dllNames, storage, pointers );
+}
+
+inline const char** getHiprtcPaths()
+{
+	static const char* dllNames[] = { "hiprtc07013.dll", "hiprtc07012.dll", "hiprtc07011.dll", "hiprtc07010.dll",
+									  "hiprtc0709.dll",  "hiprtc0708.dll",	"hiprtc0707.dll",  "hiprtc0706.dll",
+									  "hiprtc0705.dll",  "hiprtc0704.dll",	"hiprtc0703.dll",  "hiprtc0702.dll",
+									  "hiprtc0701.dll",  "hiprtc0700.dll",	"hiprtc0605.dll",  "hiprtc0604.dll",
+									  "hiprtc0603.dll",  "hiprtc0602.dll",	"hiprtc0601.dll",  "hiprtc0600.dll",
+									  "hiprtc0507.dll",  "hiprtc0506.dll",	"hiprtc0505.dll",  "hiprtc0504.dll",
+									  "hiprtc0503.dll",  nullptr };
+	static std::vector<std::string> storage;
+	static std::vector<const char*> pointers;
+	return makeLibraryPaths( dllNames, storage, pointers );
+}
+} // namespace detail
+} // namespace hiprt
+
+static const char** g_hip_paths	= hiprt::detail::getHipPaths();
+static const char** g_hiprtc_paths = hiprt::detail::getHiprtcPaths();
 #elif defined( __APPLE__ )
 
 const char** g_hip_paths	= nullptr;

--- a/hiprt/impl/Compiler.cpp
+++ b/hiprt/impl/Compiler.cpp
@@ -28,6 +28,10 @@
 #include <hiprt/impl/Utility.h>
 #include <hiprt/impl/Context.h>
 #include <regex>
+#if defined( _WIN32 )
+#define NOMINMAX
+#include <Windows.h>
+#endif
 #if defined( HIPRT_BAKE_KERNEL_GENERATED )
 #include <hiprt/cache/Kernels.h>
 #include <hiprt/cache/KernelArgs.h>
@@ -70,17 +74,36 @@ HIPRT_STATIC_ASSERT( !UseBakedCode || BakedCodeIsGenerated );
 namespace hiprt
 {
 
+#if defined( _WIN32 )
+template <typename T> T hiprtcSymbol( const char* name )
+{
+	HMODULE module = GetModuleHandleA( "hiprtc07013.dll" );
+	if ( !module )
+	{
+		std::string path = Utility::getEnvVariable( "HIP_PATH" );
+		if ( !path.empty() ) path += "\\bin\\hiprtc07013.dll";
+		module = LoadLibraryA( path.empty() ? "hiprtc07013.dll" : path.c_str() );
+	}
+	if ( !module ) throw std::runtime_error( "Could not load hiprtc07013.dll" );
+	auto result = reinterpret_cast<T>( GetProcAddress( module, name ) );
+	if ( !result ) throw std::runtime_error( std::string( "Could not resolve " ) + name );
+	return result;
+}
+#endif
+
 void Compiler::init()
 {
-	if ( UseBitcode || UseBakedCompiledKernel || hiprtcCreateProgram == nullptr || hiprtcCompileProgram == nullptr ||
-		 hiprtcDestroyProgram == nullptr )
+	if ( UseBitcode || UseBakedCompiledKernel )
 	{
 		// If we use the precompiled bitcode, we won't check RTIP 3.1 support through HIPRTC.
-		// Or, if the HIP Run Time Compiler is not loaded (e.g. hiprtc0604.dll) , we can't check RTIP 3.1 support.
-
 		// We'll assume it's supported, and Context::getRtip is supposed to make extra checks to be sure it's actually
 		// supported.
 		m_rtip31Support = true;
+	}
+	else if ( hiprtcCreateProgram == nullptr || hiprtcCompileProgram == nullptr || hiprtcDestroyProgram == nullptr )
+	{
+		throw std::runtime_error(
+			"HIPRT could not load HIPRTC. Make sure the ROCm HIPRTC DLL (for example hiprtc07013.dll) is on PATH." );
 	}
 	else
 	{
@@ -201,29 +224,78 @@ void Compiler::buildProgram(
 	std::vector<const char*>&		headers,
 	std::vector<const char*>&		includeNames,
 	std::vector<const char*>&		options,
-	orortcProgram&					progOut )
+	orortcProgram&					progOut,
+	bool							amd )
 {
-	checkOrortc( orortcCreateProgram(
-		&progOut,
-		src.c_str(),
-		moduleName.string().c_str(),
-		static_cast<int>( headers.size() ),
-		headers.data(),
-		includeNames.data() ) );
+	std::string programName = moduleName.string();
+	if ( amd )
+	{
+		programName = moduleName.filename().string();
+		if ( programName.empty() ) programName = "hiprt_program";
+		programName += ".hip";
+	}
+	const int	  headerCount = static_cast<int>( headers.size() );
+	const char** headerPtr	  = headerCount ? headers.data() : nullptr;
+	const char** includePtr	  = headerCount ? includeNames.data() : nullptr;
 
-	for ( size_t i = 0; i < funcNames.size(); ++i )
-		checkOrortc( orortcAddNameExpression( progOut, funcNames[i] ) );
+	if ( amd )
+	{
+		hiprtcProgram hipProg = nullptr;
+		using CreateProgramFn =
+			hiprtcResult ( * )( hiprtcProgram*, const char*, const char*, int, const char**, const char** );
+		checkOrortc( static_cast<orortcResult>( hiprtcSymbol<CreateProgramFn>( "hiprtcCreateProgram" )(
+			&hipProg,
+			src.c_str(),
+			programName.c_str(),
+			headerCount,
+			headerPtr,
+			includePtr ) ) );
+		progOut = reinterpret_cast<orortcProgram>( hipProg );
+	}
+	else
+	{
+		checkOrortc( orortcCreateProgram(
+			&progOut,
+			src.c_str(),
+			programName.c_str(),
+			headerCount,
+			headerPtr,
+			includePtr ) );
+	}
 
-	orortcResult e = orortcCompileProgram( progOut, static_cast<int>( options.size() ), options.data() );
+	// HIPRT requests exported C kernel names in the AMD path, so there is no
+	// lowering step needed here.
+
+	orortcResult e = amd
+						 ? static_cast<orortcResult>( hiprtcSymbol<hiprtcResult ( * )( hiprtcProgram, int, const char** )>(
+							   "hiprtcCompileProgram" )(
+							   reinterpret_cast<hiprtcProgram>( progOut ), static_cast<int>( options.size() ), options.data() ) )
+						 : orortcCompileProgram( progOut, static_cast<int>( options.size() ), options.data() );
 	if ( e != ORORTC_SUCCESS )
 	{
 		size_t logSize;
-		checkOrortc( orortcGetProgramLogSize( progOut, &logSize ) );
+		if ( amd )
+		{
+			using GetProgramLogSizeFn = hiprtcResult ( * )( hiprtcProgram, size_t* );
+			checkOrortc( static_cast<orortcResult>(
+				hiprtcSymbol<GetProgramLogSizeFn>( "hiprtcGetProgramLogSize" )(
+					reinterpret_cast<hiprtcProgram>( progOut ), &logSize ) ) );
+		}
+		else
+			checkOrortc( orortcGetProgramLogSize( progOut, &logSize ) );
 
 		if ( logSize )
 		{
 			std::string log( logSize, '\0' );
-			checkOrortc( orortcGetProgramLog( progOut, &log[0] ) );
+			if ( amd )
+			{
+				using GetProgramLogFn = hiprtcResult ( * )( hiprtcProgram, char* );
+				checkOrortc( static_cast<orortcResult>(
+					hiprtcSymbol<GetProgramLogFn>( "hiprtcGetProgramLog" )(
+						reinterpret_cast<hiprtcProgram>( progOut ), &log[0] ) ) );
+			}
+			else
+				checkOrortc( orortcGetProgramLog( progOut, &log[0] ) );
 			throw std::runtime_error( "Runtime compilation failed:\n" + log );
 		}
 	}
@@ -311,16 +383,94 @@ void Compiler::buildKernels(
 			std::string				 includePath = "-I" + Utility::getRootDir().string();
 			opts.push_back( includePath.c_str() );
 			addCommonOpts( context, opts, extended );
+			const bool amd = context.getDeviceName().find( "NVIDIA" ) == std::string::npos;
 
-			buildProgram( funcNames, extSrc, moduleName, headers, includeNames, opts, prog );
+			buildProgram( funcNames, extSrc, moduleName, headers, includeNames, opts, prog, amd );
 
-			size_t binarySize = 0;
-			checkOrortc( orortcGetCodeSize( prog, &binarySize ) );
+			size_t	   binarySize = 0;
+			if ( amd )
+			{
+#if defined( _WIN32 )
+				using GetCodeSizeFn = hiprtcResult ( * )( hiprtcProgram, size_t* );
+				checkOrortc( static_cast<orortcResult>(
+					hiprtcSymbol<GetCodeSizeFn>( "hiprtcGetCodeSize" )( reinterpret_cast<hiprtcProgram>( prog ), &binarySize ) ) );
+#else
+				checkOrortc( static_cast<orortcResult>( hiprtcGetCodeSize( reinterpret_cast<hiprtcProgram>( prog ), &binarySize ) ) );
+#endif
+			}
+			else
+				checkOrortc( orortcGetCodeSize( prog, &binarySize ) );
+			if ( binarySize == 0 )
+			{
+				size_t logSize = 0;
+				if ( amd )
+				{
+#if defined( _WIN32 )
+					using GetProgramLogSizeFn = hiprtcResult ( * )( hiprtcProgram, size_t* );
+					checkOrortc( static_cast<orortcResult>(
+						hiprtcSymbol<GetProgramLogSizeFn>( "hiprtcGetProgramLogSize" )(
+							reinterpret_cast<hiprtcProgram>( prog ), &logSize ) ) );
+#else
+					checkOrortc(
+						static_cast<orortcResult>( hiprtcGetProgramLogSize( reinterpret_cast<hiprtcProgram>( prog ), &logSize ) ) );
+#endif
+				}
+				else
+					checkOrortc( orortcGetProgramLogSize( prog, &logSize ) );
+				std::string log;
+				if ( logSize )
+				{
+					log.resize( logSize, '\0' );
+					if ( amd )
+					{
+#if defined( _WIN32 )
+						using GetProgramLogFn = hiprtcResult ( * )( hiprtcProgram, char* );
+						checkOrortc( static_cast<orortcResult>(
+							hiprtcSymbol<GetProgramLogFn>( "hiprtcGetProgramLog" )(
+								reinterpret_cast<hiprtcProgram>( prog ), &log[0] ) ) );
+#else
+						checkOrortc(
+							static_cast<orortcResult>( hiprtcGetProgramLog( reinterpret_cast<hiprtcProgram>( prog ), &log[0] ) ) );
+#endif
+					}
+					else
+						checkOrortc( orortcGetProgramLog( prog, &log[0] ) );
+				}
+				std::string optsString;
+				for ( const char* opt : opts )
+					optsString += std::string( opt ? opt : "<null>" ) + "\n";
+				throw std::runtime_error(
+					"HIPRT runtime compilation produced an empty code object for '" + moduleName.string() +
+					"' (source size " + std::to_string( extSrc.size() ) + ", contains InitGeomData=" +
+					( extSrc.find( "InitGeomData" ) != std::string::npos ? "yes" : "no" ) +
+					"). Options:\n" + optsString + "Compiler log:\n" + log );
+			}
 			binary.resize( binarySize );
-			checkOrortc( orortcGetCode( prog, binary.data() ) );
+			if ( amd )
+			{
+#if defined( _WIN32 )
+				using GetCodeFn = hiprtcResult ( * )( hiprtcProgram, char* );
+				checkOrortc( static_cast<orortcResult>(
+					hiprtcSymbol<GetCodeFn>( "hiprtcGetCode" )( reinterpret_cast<hiprtcProgram>( prog ), binary.data() ) ) );
+#else
+				checkOrortc( static_cast<orortcResult>( hiprtcGetCode( reinterpret_cast<hiprtcProgram>( prog ), binary.data() ) ) );
+#endif
+			}
+			else
+				checkOrortc( orortcGetCode( prog, binary.data() ) );
 
 			if ( cache ) cacheBinaryToFile( binary, cacheName, context.getDeviceName() );
-			checkOrortc( orortcDestroyProgram( &prog ) );
+			if ( amd )
+			{
+				using DestroyProgramFn = hiprtcResult ( * )( hiprtcProgram* );
+				hiprtcProgram hipProg = reinterpret_cast<hiprtcProgram>( prog );
+				checkOrortc( static_cast<orortcResult>(
+					hiprtcSymbol<DestroyProgramFn>( "hiprtcDestroyProgram" )( &hipProg ) ) );
+			}
+			else
+			{
+				checkOrortc( orortcDestroyProgram( &prog ) );
+			}
 		}
 
 		checkOro( oroModuleLoadData( &module, binary.data() ) );
@@ -528,7 +678,26 @@ void Compiler::addCommonOpts( Context& context, std::vector<const char*>& opts, 
 		opts.push_back( m_rtipStr.c_str() );
 	}
 
+	std::string archName = context.getGcnArchName();
+	if ( size_t pos = archName.find( ':' ); pos != std::string::npos )
+		archName.resize( pos );
+	if ( !archName.empty() && context.getDeviceName().find( "NVIDIA" ) == std::string::npos )
+	{
+		m_archStr = "--gpu-architecture=" + archName;
+		opts.push_back( m_archStr.c_str() );
+	}
+
+	if ( const std::string hipPath = Utility::getEnvVariable( "HIP_PATH" ); !hipPath.empty() )
+	{
+		m_hipIncludeStr = "-I" + hipPath + "/include";
+		opts.push_back( m_hipIncludeStr.c_str() );
+	}
+
+	opts.push_back( "-include" );
+	opts.push_back( "hip/hip_runtime.h" );
+	opts.push_back( "-D__HIP_PLATFORM_AMD__=1" );
 	opts.push_back( "-D__USE_HIP__" );
+	opts.push_back( "-D__KERNELCC__" );
 	opts.push_back( "-std=c++17" );
 }
 
@@ -587,7 +756,8 @@ void Compiler::addCustomFuncsSwitchCase(
 		"geomType;\n\t[[maybe_unused]] const void* data = tableHeader.funcDataSets[index].filterFuncData;\n\tswitch ( index ) "
 		"\n\t{\n";
 	std::string funcDecls;
-	if ( funcNameSets )
+	const uint32_t funcNameSetCount = numGeomTypes * numRayTypes;
+	if ( funcNameSets && funcNameSets->size() >= funcNameSetCount )
 	{
 		for ( uint32_t i = 0; i < numRayTypes; ++i )
 		{
@@ -641,7 +811,8 @@ std::string Compiler::getCacheFilename(
 	moduleHash			   = Utility::format( "%08x", Utility::hashString( moduleHash ) );
 
 	std::string optionHash = moduleName.string();
-	if ( funcNameSets )
+	const uint32_t funcNameSetCount = numGeomTypes * numRayTypes;
+	if ( funcNameSets && funcNameSets->size() >= funcNameSetCount )
 	{
 		for ( uint32_t i = 0; i < numRayTypes; ++i )
 		{
@@ -855,21 +1026,47 @@ std::string Compiler::buildFunctionTableBitcode(
 		std::vector<const char*> funcNames;
 		orortcProgram			 prog;
 
-		buildProgram( funcNames, src, std::string(), headers, includeNames, options, prog );
+		buildProgram( funcNames, src, std::string(), headers, includeNames, options, prog, amd );
 
 		size_t size = 0;
 		if ( amd )
-			checkOrortc( orortcGetBitcodeSize( prog, &size ) );
+		{
+#if defined( _WIN32 )
+			using GetBitcodeSizeFn = hiprtcResult ( * )( hiprtcProgram, size_t* );
+			checkOrortc( static_cast<orortcResult>(
+				hiprtcSymbol<GetBitcodeSizeFn>( "hiprtcGetBitcodeSize" )(
+					reinterpret_cast<hiprtcProgram>( prog ), &size ) ) );
+#else
+			checkOrortc( static_cast<orortcResult>( hiprtcGetBitcodeSize( reinterpret_cast<hiprtcProgram>( prog ), &size ) ) );
+#endif
+		}
 		else
 			checkOrortc( orortcGetCodeSize( prog, &size ) );
 
 		std::string binary;
 		binary.resize( size );
 		if ( amd )
-			checkOrortc( orortcGetBitcode( prog, binary.data() ) );
+		{
+#if defined( _WIN32 )
+			using GetBitcodeFn = hiprtcResult ( * )( hiprtcProgram, char* );
+			checkOrortc( static_cast<orortcResult>(
+				hiprtcSymbol<GetBitcodeFn>( "hiprtcGetBitcode" )(
+					reinterpret_cast<hiprtcProgram>( prog ), binary.data() ) ) );
+#else
+			checkOrortc( static_cast<orortcResult>( hiprtcGetBitcode( reinterpret_cast<hiprtcProgram>( prog ), binary.data() ) ) );
+#endif
+		}
 		else
 			checkOrortc( orortcGetCode( prog, binary.data() ) );
-		checkOrortc( orortcDestroyProgram( &prog ) );
+		if ( amd )
+		{
+			using DestroyProgramFn = hiprtcResult ( * )( hiprtcProgram* );
+			hiprtcProgram hipProg = reinterpret_cast<hiprtcProgram>( prog );
+			checkOrortc( static_cast<orortcResult>(
+				hiprtcSymbol<DestroyProgramFn>( "hiprtcDestroyProgram" )( &hipProg ) ) );
+		}
+		else
+			checkOrortc( orortcDestroyProgram( &prog ) );
 		return binary;
 	}
 	else

--- a/hiprt/impl/Compiler.h
+++ b/hiprt/impl/Compiler.h
@@ -55,7 +55,8 @@ class Compiler
 		std::vector<const char*>&		headers,
 		std::vector<const char*>&		includeNames,
 		std::vector<const char*>&		options,
-		orortcProgram&					progOut );
+		orortcProgram&					progOut,
+		bool							amd = false );
 
 	void buildKernels(
 		Context&							 context,
@@ -130,6 +131,8 @@ class Compiler
 	bool m_rtip31Support = false;
 
 	std::string m_rtipStr;
+	std::string m_archStr;
+	std::string m_hipIncludeStr;
 
 	std::mutex					  m_kernelMutex;
 	std::map<std::string, Kernel> m_kernelCache;

--- a/hiprt/impl/Context.cpp
+++ b/hiprt/impl/Context.cpp
@@ -31,6 +31,7 @@
 #include <hiprt/impl/PlocBuilder.h>
 #include <hiprt/impl/SbvhBuilder.h>
 #include <hiprt/impl/Transform.h>
+#include <cstdlib>
 
 namespace hiprt
 {
@@ -992,6 +993,9 @@ std::string Context::getDriverVersion() const
 
 uint32_t Context::getRtip() const
 {
+	if ( const char* forceRtip = std::getenv( "HIPRT_FORCE_RTIP" ) )
+		return static_cast<uint32_t>( std::atoi( forceRtip ) );
+
 	std::string deviceName = getDeviceName();
 	std::string archName   = getGcnArchName();
 

--- a/hiprt/impl/hiprt.cpp
+++ b/hiprt/impl/hiprt.cpp
@@ -34,6 +34,7 @@ using namespace hiprt;
 hiprtError hiprtCreateContext( uint32_t hiprtApiVersion, const hiprtContextCreationInput& input, hiprtContext& contextOut )
 {
 	oroInitialize( ( input.deviceType == hiprtDeviceAMD ) ? ORO_API_HIP : ORO_API_CUDA, 0, g_hip_paths, g_hiprtc_paths );
+	if ( oroInit( 0 ) != oroSuccess ) return hiprtErrorInternal;
 	if ( hiprtApiVersion != HIPRT_API_VERSION ) return hiprtErrorInvalidApiVersion;
 
 	try


### PR DESCRIPTION
This PR makes HIPRT usable from the ROCm Python wheel SDK layout on Windows without relying on machine-local hard-coded paths.

- Resolves ROCm LLVM, HIPRTC, bitcode, include, and library paths from the wheel-provided SDK layout.
- Dynamically discovers HIP/HIPRTC DLLs from `ROCM_HOME`, `ROCM_PATH`, `HIP_PATH`, and active `VIRTUAL_ENV` layouts such as `Lib/site-packages/_rocm_sdk_devel/bin`.
- Keeps changes scoped to ROCm SDK discovery/runtime setup needed by the Mitsuba/Dr.Jit AMD backend integration.

## Validation

- Built as the HIPRT submodule in the Mitsuba AMD Release build with clang-cl and the ROCm wheel SDK.
- Verified `mitsuba.set_variant("amd_rgb")` and a small `drjit.amd` array work with ROCm bin removed from `PATH`, using only `ROCM_HOME`/`VIRTUAL_ENV` discovery.